### PR TITLE
Add support for STAYPARAMDEF files

### DIFF
--- a/STAYPARAMDEF.bt
+++ b/STAYPARAMDEF.bt
@@ -20,12 +20,16 @@ typedef struct {
 
 Header header;
 
+local int counter = 0;
+
 typedef struct {
     enum <int> { TYPE_FLOAT = 6, TYPE_INT = 4, TYPE_SHORT = 2, TYPE_BYTE = 0} type;
     Assert(type == TYPE_FLOAT || type == TYPE_INT || type == TYPE_SHORT || type == TYPE_BYTE, "Unrecognized type");
 
     quad padding <hidden=true> ;
     Assert(padding == 0);
+
+    local int index = counter++;
 
     if (type == TYPE_BYTE) {
         byte defaultValue;
@@ -48,7 +52,12 @@ typedef struct {
         float minValue;
         float maxValue;
     }
-} Field <bgcolor=cLtGreen, optimize=false>;
+} Field <read=ReadField, bgcolor=cLtGreen, optimize=false> ;
+
+
+string ReadField(Field &field) {
+    return names[field.index].displayName;
+}
 
 FSkip(4 * header.fieldCount);
 

--- a/STAYPARAMDEF.bt
+++ b/STAYPARAMDEF.bt
@@ -1,0 +1,61 @@
+//------------------------------------------------
+//--- 010 Editor v11.0.1 Binary Template
+//
+//      File: STAYPARAMDEF.bt
+//   Authors: sfix
+//   Version:
+//   Purpose: Companion file that describes the structure of stayparam files.
+//  Category: Dantelion
+// File Mask: *.stayparamdef
+//  ID Bytes:
+//   History:
+//------------------------------------------------
+
+typedef struct {
+    uint fieldCount;
+    uint unk;
+    uint unk2;
+    uint unk3;
+} Header <bgcolor=cLtRed>;
+
+Header header;
+
+typedef struct {
+    enum <int> { TYPE_FLOAT = 6, TYPE_INT = 4, TYPE_SHORT = 2, TYPE_BYTE = 0} type;
+    Assert(type == TYPE_FLOAT || type == TYPE_INT || type == TYPE_SHORT || type == TYPE_BYTE, "Unrecognized type");
+
+    quad padding <hidden=true> ;
+    Assert(padding == 0);
+
+    if (type == TYPE_BYTE) {
+        byte defaultValue;
+        byte increment;
+        byte minValue;
+        byte maxValue;
+    } else if (type == TYPE_SHORT) {
+        short defaultValue;
+        short increment;
+        short minValue;
+        short maxValue;
+    } else if (type == TYPE_INT) {
+        int defaultValue;
+        int increment;
+        int minValue;
+        int maxValue;
+    } else if (type == TYPE_FLOAT) {
+        float defaultValue;
+        float increment;
+        float minValue;
+        float maxValue;
+    }
+} Field <bgcolor=cLtGreen, optimize=false>;
+
+FSkip(4 * header.fieldCount);
+
+typedef struct{
+    string displayName;
+    string displayFormat;
+} FieldName <optimize=false>;
+
+Field fields[header.fieldCount];
+FieldName names[header.fieldCount];


### PR DESCRIPTION
The `padding` inside of a `Field` might potentially be the offsets to the two strings in `FieldName`, but they're zeroed out in the example stayparamdef file I have.